### PR TITLE
Fix unused JS by lazy-loading booking map

### DIFF
--- a/src/components/BookingModal.astro
+++ b/src/components/BookingModal.astro
@@ -56,7 +56,6 @@ const { id = 'booking-modal' } = Astro.props;
       this.serviceMapping = null;
       
       this.init();
-      this.loadServiceMapping();
     }
     
     init() {
@@ -85,9 +84,13 @@ const { id = 'booking-modal' } = Astro.props;
     setupBookingButtons() {
       const buttons = document.querySelectorAll('[data-booking-url], [data-service-id]');
       buttons.forEach(button => {
-        button.addEventListener('click', (e) => {
+        button.addEventListener('click', async (e) => {
           e.preventDefault();
           const serviceId = button.getAttribute('data-service-id') || 'general';
+
+          if (!this.serviceMapping) {
+            await this.loadServiceMapping();
+          }
           
           // Use service mapping for URL if available
           let url = button.getAttribute('data-booking-url');
@@ -164,6 +167,7 @@ const { id = 'booking-modal' } = Astro.props;
     }
     
     async loadServiceMapping() {
+      if (this.serviceMapping) return;
       try {
         const module = await import('../scripts/serviceMapping.js');
         this.serviceMapping = module.serviceMapping;


### PR DESCRIPTION
## Summary
- lazy-load booking mapping only after user interaction to reduce unused JS

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_688c8d6a16208329a3c9e317e61d7b58